### PR TITLE
Add #comment support to input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ source .env
 Input files are in the following format:
 
 ```bash
+# lines beginning with "#" are ignored as a comment
 ENV_VAR_NAME=secret-name/secret-key
 ENV_VAR_NAME_2=secret-name/secret-key-2
 ENV_VAR_NAME_3=other-secret-name/other-key

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -20,6 +20,9 @@ func ParseInput(input string) (EnvKeyToSecretPath, error) {
 	}
 	for i, line := range lines {
 		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
 		if !strings.Contains(line, "=") {
 			return nil, fmt.Errorf("parse input error: line %d missing required \"=\" separated env pair", i+1)
 		}
@@ -41,6 +44,9 @@ func ParseInput(input string) (EnvKeyToSecretPath, error) {
 			SecretName: strings.Join(secretParts[:len(secretParts)-1], "/"),
 			Key:        secretParts[len(secretParts)-1],
 		}
+	}
+	if len(output) < 1 {
+		return nil, fmt.Errorf("parse input error: no secrets defined in input file")
 	}
 
 	return output, nil


### PR DESCRIPTION
```bash
 # lines beginning with "#" are now ignored as a comment 
 ENV_VAR_NAME=secret-name/secret-key 
```